### PR TITLE
Updated ss-user model in ss-user.json

### DIFF
--- a/common/models/ss-user.json
+++ b/common/models/ss-user.json
@@ -12,7 +12,7 @@
     },
     "password": {
       "type": "string",
-      "required": true
+      "required": false
     },
     "dateOfBirth": {
       "type": "date",


### PR DESCRIPTION
SsUsersProvider methods besides  login(user) and register(user) should not require password to be present in the passed ss-user model. For example, SsUsersProvider.updateUser(userId, token, SSUser) should be processed with the userId rather than the password. Instead of being required, the password should be optional. 